### PR TITLE
Set 64px mode to distance+ambient on start

### DIFF
--- a/scripts/evo_64px.py
+++ b/scripts/evo_64px.py
@@ -182,36 +182,37 @@ class Evo64px(object):
                 if ord(ack[2]) == 0:
                     return True
                 else:
-                    print "Command not acknowledged"
+                    rospy.logerr("Command refused by device")
                     return False
             else:
-                print "Error in ACK checksum"
+                rospy.logerr("Invalid sensor answer to command")
                 return False
 
     def start_sensor(self):
-        rospy.loginfo("Starting sensor...")
+        rospy.loginfo("Configuring sensor...")
         res = self.send_command("\x00\x11\x03\x4B")
         if res:
-            rospy.loginfo("Activated distance and ambient mode")
+            rospy.loginfo("Distance and ambient mode activated successfully")
         else:
             rospy.logerr("Failed to activate distance and ambient mode")
 
+        rospy.loginfo("Starting sensor output...")
         res = self.send_command("\x00\x52\x02\x01\xDF")
         if res:
-            rospy.loginfo("Sensor started successfully")
+            rospy.loginfo("Sensor output started successfully")
             return True
         else:
-            rospy.logerr("Failed to start sensor")
+            rospy.logerr("Failed to start sensor output")
             return False
 
     def stop_sensor(self):
-        rospy.loginfo("Stopping sensor...")
+        rospy.loginfo("Stopping sensor output ...")
         res = self.send_command("\x00\x52\x02\x00\xD8")
         if res:
-            rospy.loginfo("Sensor stopped successfully")
+            rospy.loginfo("Sensor output stopped successfully")
             return True
         else:
-            rospy.logerr("Failed to stop sensor")
+            rospy.logerr("Failed to stop sensor output")
             return False
 
     def run(self):

--- a/scripts/evo_64px.py
+++ b/scripts/evo_64px.py
@@ -129,7 +129,7 @@ class Evo64px(object):
         while not got_frame:
             with self.serial_lock:
                 frame = self.port.readline()
-            if len(frame) == 269:
+            if len(frame) in (269, 141):
                 if ord(frame[0]) == 0x11 and self.crc_check(frame):  # Check for range frame header and crc
                     dec_out = []
                     for i in range(1, 65):

--- a/scripts/evo_64px.py
+++ b/scripts/evo_64px.py
@@ -190,6 +190,12 @@ class Evo64px(object):
 
     def start_sensor(self):
         rospy.loginfo("Starting sensor...")
+        res = self.send_command("\x00\x11\x03\x4B")
+        if res:
+            rospy.loginfo("Activated distance and ambient mode")
+        else:
+            rospy.logerr("Failed to activate distance and ambient mode")
+
         res = self.send_command("\x00\x52\x02\x01\xDF")
         if res:
             rospy.loginfo("Sensor started successfully")

--- a/scripts/evo_thermal.py
+++ b/scripts/evo_thermal.py
@@ -289,27 +289,27 @@ class EvoThermal(object):
         if ord(temp_ack[2]) == 0:
             return True
         else:
-            rospy.logerr("Command not acknowledged")
+            rospy.logerr("Command refused by device")
             return False
 
     def start_sensor(self):
-        rospy.loginfo("Starting sensor...")
+        rospy.loginfo("Starting sensor output...")
         res = self.send_command("\x00\x52\x02\x01\xDF")
         if res:
-            rospy.loginfo("Sensor started successfully")
+            rospy.loginfo("Sensor output started successfully")
             return True
         else:
-            rospy.logerr("Failed to start sensor")
+            rospy.logerr("Failed to start sensor output")
             return False
 
     def stop_sensor(self):
-        rospy.loginfo("Stopping sensor...")
+        rospy.loginfo("Stopping sensor output...")
         res = self.send_command("\x00\x52\x02\x00\xD8")
         if res:
-            rospy.loginfo("Sensor stopped successfully")
+            rospy.loginfo("Sensor output stopped successfully")
             return True
         else:
-            rospy.logerr("Failed to stop sensor")
+            rospy.logerr("Failed to stop sensor output")
             return False
 
     def run(self):


### PR DESCRIPTION
Fix #22.

The driver assumes the sensor to be in this mode, so if it isn't, the sensor
isn't able to read data packets. This change has the sensor set the mode when
starting up, so it's guaranteed to be in the expected mode.