### PR TITLE
scripts/evo_64px.py, cfg/EvoThermal.cfg, cfg/Evo64px.cfg: use /usr/bi…

### DIFF
--- a/cfg/Evo64px.cfg
+++ b/cfg/Evo64px.cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 PACKAGE = "teraranger_evo_64px"
 from dynamic_reconfigure.parameter_generator_catkin import *
 

--- a/cfg/EvoThermal.cfg
+++ b/cfg/EvoThermal.cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 PACKAGE = "teraranger"
 
 from dynamic_reconfigure.parameter_generator_catkin import *

--- a/scripts/evo_64px.py
+++ b/scripts/evo_64px.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import numpy as np
 import serial


### PR DESCRIPTION
…n/env python shebang

* like other scripts and .cfg files do:
  cfg/TerarangerDuo.cfg:#!/usr/bin/env python
  cfg/TerarangerOne.cfg:#!/usr/bin/env python
  scripts/evo_thermal.py:#!/usr/bin/env python2

Signed-off-by: Martin Jansa <martin.jansa@lge.com>