### PR TITLE
remove unexistent library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ generate_dynamic_reconfigure_options(
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp sensor_msgs std_msgs dynamic_reconfigure serial teraranger_array
   DEPENDS Boost
 )


### PR DESCRIPTION
The `teranger` library is included as being exported in the CMakeLists but it is not being built so including the `teranger` package as dependency in new packages CMakeLists leads to failure.

Signed-off-by: Servando German Serrano <servando.german.serrano@gmail.com>